### PR TITLE
handle node disconnects gracefully

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -37,8 +37,8 @@ pub fn get_data(allocator: std.mem.Allocator, stream: net.Stream, sensors: []con
 
 pub fn handle_client(allocator: std.mem.Allocator, conn: std.net.Server.Connection, sensors: []const tcp.SensorType, gauges: std.ArrayList(prometheus.Gauge)) !void {
     const remote_address = try net.Address.parseIp4("127.0.0.1", 8080);
-    const remote_stream = net.tcpConnectToAddress(remote_address) catch |err| {
-        std.log.warn("\x1b[33mCan't connect to address: {any}... error: {any}\x1b[0m", .{ remote_address, err });
+    const remote_stream = net.tcpConnectToAddress(remote_address) catch {
+        std.log.warn("\x1b[33mCan't connect to address: {any}\x1b[0m", .{remote_address});
         return;
     };
     std.log.info("\x1b[32mClient initializing communication with remote address: {any}....\x1b[0m", .{remote_address});

--- a/src/client.zig
+++ b/src/client.zig
@@ -47,7 +47,7 @@ pub fn handle_client(allocator: std.mem.Allocator, conn: std.net.Server.Connecti
     while (http_server.state == .ready) {
         var request = http_server.receiveHead() catch |err| {
             if (err != error.HttpConnectionClosing) {
-                std.log.debug("connection error: {s}\n", .{@errorName(err)});
+                std.log.warn("\x1b[33mConnection error\x1b[0m: {s}\n", .{@errorName(err)});
             }
             continue;
         };
@@ -55,7 +55,7 @@ pub fn handle_client(allocator: std.mem.Allocator, conn: std.net.Server.Connecti
         const target = request.head.target;
         if (std.mem.eql(u8, target, "/metrics")) {
             const data = get_data(allocator, remote_stream, sensors) catch |err| {
-                std.log.warn("failed to get data: {s}", .{@errorName(err)});
+                std.log.warn("\x1b[33mFailed to get data\x1b[0m: {s}", .{@errorName(err)});
                 continue;
             };
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -111,9 +111,13 @@ pub fn main() !void {
     std.log.info("\x1b[32mHTTP Server listening on {any}\x1b[0m", .{server_address});
 
     while (true) {
+        // NOTE: putting this here makes me connect to the remote node twice.
+        // when I move it outside the while loop it works as desired
+        // I think we want to move the connection to the remote node to handle_client
         const remote_address = try net.Address.parseIp4("127.0.0.1", 8080);
         const remote_stream = net.tcpConnectToAddress(remote_address) catch |err| {
             std.log.err("Can't connect to address: {any}... error: {any}", .{ remote_address, err });
+            std.time.sleep(6e10);
             continue;
         };
         std.log.info("\x1b[32mClient initializing communication with remote address: {any}....\x1b[0m", .{remote_address});

--- a/src/client.zig
+++ b/src/client.zig
@@ -82,13 +82,6 @@ pub fn handle_client(allocator: std.mem.Allocator, conn: std.net.Server.Connecti
 pub fn main() !void {
     // NOTE: this can only happen once
     // if the node dies, the client can't reconnect unless you shut down the program and restart it
-    const remote_address = try net.Address.parseIp4("127.0.0.1", 8080);
-    const remote_stream = net.tcpConnectToAddress(remote_address) catch |err| {
-        std.log.err("Can't connect to address: {any}... error: {any}", .{ remote_address, err });
-        return error.ConnectionRefused;
-    };
-    std.log.info("\x1b[32mClient initializing communication with remote address: {any}....\x1b[0m", .{remote_address});
-    defer remote_stream.close();
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -118,6 +111,13 @@ pub fn main() !void {
     std.log.info("\x1b[32mHTTP Server listening on {any}\x1b[0m", .{server_address});
 
     while (true) {
+        const remote_address = try net.Address.parseIp4("127.0.0.1", 8080);
+        const remote_stream = net.tcpConnectToAddress(remote_address) catch |err| {
+            std.log.err("Can't connect to address: {any}... error: {any}", .{ remote_address, err });
+            continue;
+        };
+        std.log.info("\x1b[32mClient initializing communication with remote address: {any}....\x1b[0m", .{remote_address});
+        defer remote_stream.close();
         const conn = tcp_server.accept() catch |err| {
             std.log.err("\x1b[31mServer failed to connect to client:\x1b[0m {any}", .{err});
             continue;

--- a/src/lib/device.zig
+++ b/src/lib/device.zig
@@ -32,13 +32,8 @@ pub fn parse_rain(allocator: Allocator) !?[]const f32 {
         std.log.info("\x1b[31mCould not open serial device, sending nan to the client\x1b[0m", .{});
         return null;
     };
+
     var buf = ArrayList(f32).init(allocator);
-
-    // TODO: c.get_rain() can return a null pointer (see rg15.c get_rain())
-    // This will eventually get handled when we rewrite rg15.c in zig
-    // but it crashes the server because of an assert in std.mem.span
-    // what to do about it now?
-
     const rain_data: []const u8 = std.mem.span(c.get_rain());
     if (rain_data.len < 4) return null;
 

--- a/src/lib/tcp.zig
+++ b/src/lib/tcp.zig
@@ -8,7 +8,7 @@ const net = std.net;
 
 pub const PacketType = enum(u8) { SensorRequest, SensorResponse };
 pub const SensorType = enum(u8) { Temp, Pres, Hum, Gas, RainAcc, RainEventAcc, RainTotalAcc, RainRInt };
-pub const TCPError = error{ VersionError, InvalidPacketType, InvalidSensorType, DeviceError, BadPacket };
+pub const TCPError = error{ VersionError, InvalidPacketType, InvalidSensorType, DeviceError, BadPacket, ConnectionError };
 
 pub const ClientHandler = struct {
     stream: net.Stream,


### PR DESCRIPTION
Currently, when a node goes down and the client is disconnected, we can't reconnect without shutting down client.zig and bringing it back up